### PR TITLE
📝 docs(readme): update preview link for cmake-docs-l10n

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
     <tr>
       <td rowspan="1" colspan="1" align="left"   style="text-align: left;"  ><div class="project-id">cmake-docs-l10n</div></td>
       <td rowspan="1" colspan="1" align="center" style="text-align: center;"><div class="project-links">
-        <a href="https://localizethedocs.github.io/cmake-docs-l10n">Preview</a> ·
+        <a href="https://projects.localizethedocs.org/cmake-docs-l10n">Preview</a> ·
         <a href="https://localizethedocs.crowdin.com/cmake-docs-l10n">Crowdin</a> ·
         <a href="https://github.com/localizethedocs/cmake-docs-l10n">GitHub</a> ·
         <a href="https://gitcode.com/localizethedocs/cmake-docs-l10n">GitCode</a> ·


### PR DESCRIPTION
Updated the preview link URL:

From: https://localizethedocs.github.io/cmake-docs-l10n
To: https://projects.localizethedocs.org/cmake-docs-l10n